### PR TITLE
multi: rename zcashd -> zsided

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,10 +53,9 @@ jobs:
         with: 
           name: binaries-${{ runner.os }}
           if-no-files-found: error
-          # TODO: Update these when renaming the binaries produced
           path: |
-            src/zcashd
-            src/zcash-cli
+            src/zsided
+            src/zside-cli
 
 
   build-macos: 
@@ -109,7 +108,6 @@ jobs:
         with: 
           name: binaries-${{ runner.os }}
           if-no-files-found: error
-          # TODO: Update these when renaming the binaries produced
           path: |
-            src/zcashd
-            src/zcash-cli
+            src/zsided
+            src/zside-cli

--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,11 @@
 *.deb
 *.exe
 src/bitcoin
-src/zcashd
-src/zcashd-wallet-tool
-src/zcash-cli
-src/zcash-gtest
-src/zcash-tx
+src/zsided
+src/zsided-wallet-tool
+src/zside-cli
+src/zside-gtest
+src/zside-tx
 src/test/test_bitcoin
 zcutil/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,18 +35,18 @@ RUN export CONFIG_SITE="/depends/$(./depends/config.guess)/share/config.site" &&
     make
 
 # Verify the binary is working
-RUN ./src/zcashd --help
+RUN ./src/zsided --help
 
 FROM debian:bookworm-slim AS final
 
 # Quality of life for working with RPC API
 RUN apt-get update && apt-get install -y curl
 
-COPY --from=worker /src/zcashd /src/zcash-cli /usr/bin
+COPY --from=worker /src/zcashd /src/zside-cli /usr/bin
 
 COPY --from=params-fetcher /root/.zcash-params /root/.zcash-params
 
 # Verify the binary is working and installed
-RUN zcashd --help
+RUN zsided --help
 
-ENTRYPOINT ["zcashd"]
+ENTRYPOINT ["zsided"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+Zside 
+===========
+
+What is Zside?
+--------------
+
+Zside is a Bitcoin sidechain based off of [Zcash](https://z.cash/).
+
+is an implementation of the "Zerocash" protocol.
+Based on Bitcoin's code, Zcash intends to offer a far higher standard of privacy
+through a sophisticated zero-knowledge proving scheme that preserves
+confidentiality of transaction metadata. More technical details are available
+in our [Protocol Specification](https://zips.z.cash/protocol/protocol.pdf).
+
+This software is the Zside client. 
+
+<p align="center">
+  <img src="doc/imgs/zcashd_screen.gif" height="500">
+</p>
+
 ## Build from Source (Sidechain Version)
 
 ### Non-Nix (Ubuntu)
@@ -102,58 +122,6 @@ make -j8 # or number of cores you want to use
 ### Regtest Demo Script
 
 A script for: activating this sidechain (on [drivechain](https://github.com/drivechain-project/mainchain/)), mining blocks, depositing and withdrawing coins, generating t/z addresses and using them, is [available here](zside-tour-2022.sh).
-
-
---------------------------
-
-
-
-Zcash 5.0.0
-<img align="right" width="120" height="80" src="doc/imgs/logo.png">
-===========
-
-What is Zcash?
---------------
-
-[Zcash](https://z.cash/) is an implementation of the "Zerocash" protocol.
-Based on Bitcoin's code, Zcash intends to offer a far higher standard of privacy
-through a sophisticated zero-knowledge proving scheme that preserves
-confidentiality of transaction metadata. More technical details are available
-in our [Protocol Specification](https://zips.z.cash/protocol/protocol.pdf).
-
-This software is the Zcash client. It downloads and stores the entire history
-of Zcash transactions; depending on the speed of your computer and network
-connection, the synchronization process could take a day or more once the
-blockchain has reached a significant size.
-
-<p align="center">
-  <img src="doc/imgs/zcashd_screen.gif" height="500">
-</p>
-
-#### :lock: Security Warnings
-
-See important security warnings on the
-[Security Information page](https://z.cash/support/security/).
-
-**Zcash is experimental and a work in progress.** Use it at your own risk.
-
-####  :ledger: Deprecation Policy
-
-This release is considered deprecated 16 weeks after the release day. There
-is an automatic deprecation shutdown feature which will halt the node some
-time after this 16-week period. The automatic feature is based on block
-height.
-
-#### Need Help?
-
-* :blue_book: See the documentation at the [ReadTheDocs](https://zcash.readthedocs.io)
-  for help and more information.
-* :incoming_envelope: Ask for help on the [Zcash](https://forum.z.cash/) forum.
-* :speech_balloon: Join our community on [Discord](https://discordapp.com/invite/PhJY6Pm)
-
-Participation in the Zcash project is subject to a
-[Code of Conduct](code_of_conduct.md).
-
 
 License
 -------

--- a/configure.ac
+++ b/configure.ac
@@ -14,9 +14,9 @@ AC_CONFIG_HEADERS([src/config/bitcoin-config.h])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([build-aux/m4])
 
-BITCOIN_DAEMON_NAME=zcashd
-BITCOIN_CLI_NAME=zcash-cli
-BITCOIN_TX_NAME=zcash-tx
+BITCOIN_DAEMON_NAME=zsided
+BITCOIN_CLI_NAME=zside-cli
+BITCOIN_TX_NAME=zside-tx
 
 dnl Unless the user specified ARFLAGS, force it to be cr
 AC_ARG_VAR(ARFLAGS, [Flags for the archiver, defaults to <cr> if not set])
@@ -351,7 +351,7 @@ CPPFLAGS="$CPPFLAGS -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS"
 
 AC_ARG_WITH([utils],
   [AS_HELP_STRING([--with-utils],
-  [build zcash-cli zcash-tx (default=yes)])],
+  [build zside-cli zside-tx (default=yes)])],
   [build_bitcoin_utils=$withval],
   [build_bitcoin_utils=yes])
 
@@ -884,7 +884,7 @@ AC_MSG_CHECKING([whether to build bitcoind])
 AM_CONDITIONAL([BUILD_BITCOIND], [test x$build_bitcoind = xyes])
 AC_MSG_RESULT($build_bitcoind)
 
-AC_MSG_CHECKING([whether to build utils (zcash-cli zcash-tx)])
+AC_MSG_CHECKING([whether to build utils (zside-cli zside-tx)])
 AM_CONDITIONAL([BUILD_BITCOIN_UTILS], [test x$build_bitcoin_utils = xyes])
 AC_MSG_RESULT($build_bitcoin_utils)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -123,11 +123,11 @@ TESTS =
 BENCHMARKS =
 
 if BUILD_BITCOIND
-  bin_PROGRAMS += zcashd
+  bin_PROGRAMS += zsided
 endif
 
 if BUILD_BITCOIN_UTILS
-  bin_PROGRAMS += zcash-cli zcash-tx
+  bin_PROGRAMS += zside-cli zside-tx
   bin_SCRIPTS += $(WALLET_TOOL_BIN)
 endif
 
@@ -289,7 +289,7 @@ obj/build.h: FORCE
 	  $(abs_top_srcdir)
 libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
 
-# server: zcashd
+# server: zsided
 libbitcoin_server_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS)
 libbitcoin_server_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_server_a_SOURCES = \
@@ -345,7 +345,7 @@ libbitcoin_zmq_a_SOURCES = \
   zmq/zmqpublishnotifier.cpp
 endif
 
-# wallet: zcashd, but only linked when wallet enabled
+# wallet: zsided, but only linked when wallet enabled
 libbitcoin_wallet_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_wallet_a_SOURCES = \
@@ -406,7 +406,7 @@ crypto_libbitcoin_crypto_a_SOURCES += \
   ${EQUIHASH_TROMP_SOURCES}
 endif
 
-# common: shared between zcashd and non-server tools
+# common: shared between zsided and non-server tools
 libbitcoin_common_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_common_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_common_a_SOURCES = \
@@ -477,7 +477,7 @@ if GLIBC_BACK_COMPAT
 libbitcoin_util_a_SOURCES += compat/glibc_compat.cpp
 endif
 
-# cli: zcash-cli
+# cli: zside-cli
 libbitcoin_cli_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_cli_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_cli_a_SOURCES = \
@@ -489,16 +489,16 @@ nodist_libbitcoin_util_a_SOURCES = $(srcdir)/obj/build.h
 #
 
 # bitcoind binary #
-zcashd_SOURCES = bitcoind.cpp
-zcashd_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
-zcashd_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
-zcashd_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+zsided_SOURCES = bitcoind.cpp
+zsided_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+zsided_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+zsided_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 
 if TARGET_WINDOWS
-zcashd_SOURCES += bitcoind-res.rc
+zsided_SOURCES += bitcoind-res.rc
 endif
 
-zcashd_LDADD = \
+zsided_LDADD = \
   $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_WALLET) \
   $(LIBBITCOIN_COMMON) \
@@ -514,7 +514,7 @@ zcashd_LDADD = \
   $(LIBMEMENV) \
   $(LIBSECP256K1)
 
-zcashd_LDADD += \
+zsided_LDADD += \
   $(BOOST_LIBS) \
   $(BDB_LIBS) \
   $(EVENT_PTHREADS_LIBS) \
@@ -524,16 +524,16 @@ zcashd_LDADD += \
   $(LIBZCASH_LIBS)
 
 # bitcoin-cli binary #
-zcash_cli_SOURCES = bitcoin-cli.cpp
-zcash_cli_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CFLAGS)
-zcash_cli_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
-zcash_cli_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+zside_cli_SOURCES = bitcoin-cli.cpp
+zside_cli_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CFLAGS)
+zside_cli_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+zside_cli_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 
 if TARGET_WINDOWS
-zcash_cli_SOURCES += bitcoin-cli-res.rc
+zside_cli_SOURCES += bitcoin-cli-res.rc
 endif
 
-zcash_cli_LDADD = \
+zside_cli_LDADD = \
   $(LIBBITCOIN_CLI) \
   $(LIBUNIVALUE) \
   $(LIBBITCOIN_UTIL) \
@@ -547,18 +547,18 @@ zcash_cli_LDADD = \
   $(LIBZCASH_LIBS)
 #
 
-# zcash-tx binary #
-zcash_tx_SOURCES = bitcoin-tx.cpp
-zcash_tx_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
-zcash_tx_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
-zcash_tx_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+# zside-tx binary #
+zside_tx_SOURCES = bitcoin-tx.cpp
+zside_tx_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+zside_tx_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+zside_tx_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 
 if TARGET_WINDOWS
-zcash_tx_SOURCES += bitcoin-tx-res.rc
+zside_tx_SOURCES += bitcoin-tx-res.rc
 endif
 
-# FIXME: Is libzcash needed for zcash_tx?
-zcash_tx_LDADD = \
+# FIXME: Is libzcash needed for zside_tx?
+zside_tx_LDADD = \
   $(LIBUNIVALUE) \
   $(LIBBITCOIN_COMMON) \
   $(LIBBITCOIN_UTIL) \
@@ -569,7 +569,7 @@ zcash_tx_LDADD = \
   $(LIBBITCOIN_CRYPTO) \
   $(LIBZCASH_LIBS)
 
-zcash_tx_LDADD += $(BOOST_LIBS)
+zside_tx_LDADD += $(BOOST_LIBS)
 #
 
 # zcash protocol primitives #

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -89,7 +89,7 @@ bool AppInit(int argc, char* argv[])
         else
         {
             strUsage += "\n" + _("Usage:") + "\n" +
-                  "  zcashd [options]                     " + _("Start Zcash Daemon") + "\n";
+                  "  zsided [options]                     " + _("Start Zcash Sidechain Daemon") + "\n";
 
             strUsage += "\n" + HelpMessage(HMM_BITCOIND);
         }
@@ -119,11 +119,11 @@ bool AppInit(int argc, char* argv[])
         } catch (const missing_zcash_conf& e) {
             auto confFilename = GetArg("-conf", BITCOIN_CONF_FILENAME);
             fprintf(stderr,
-                (_("Before starting zcashd, you need to create a configuration file:\n"
+                (_("Before starting zsided, you need to create a configuration file:\n"
                    "%s\n"
                    "It can be completely empty! That indicates you are happy with the default\n"
-                   "configuration of zcashd. But requiring a configuration file to start ensures\n"
-                   "that zcashd won't accidentally compromise your privacy if there was a default\n"
+                   "configuration of zsided. But requiring a configuration file to start ensures\n"
+                   "that zsided won't accidentally compromise your privacy if there was a default\n"
                    "option you needed to change.\n"
                    "\n"
                    "You can look at the example configuration file for suggestions of default\n"
@@ -155,7 +155,7 @@ bool AppInit(int argc, char* argv[])
 
         if (fCommandLine)
         {
-            fprintf(stderr, "Error: There is no RPC client functionality in zcashd. Use the zcash-cli utility instead.\n");
+            fprintf(stderr, "Error: There is no RPC client functionality in zsided. Use the zcash-cli utility instead.\n");
             exit(EXIT_FAILURE);
         }
 #ifndef WIN32


### PR DESCRIPTION
Renames the binaries produced: `zcashd` -> `zsided`. Could have done a lot more thorough search and replace, but there's no point in that. 